### PR TITLE
Change speakers to teachers

### DIFF
--- a/course.html
+++ b/course.html
@@ -86,7 +86,7 @@
 										<li>
 											<span class="opener">Team</span>
 											<ul>
-												<li><a href="team.html#speaker">Speakers</a></li>
+												<li><a href="team.html#teacher">Teachers</a></li>
 												<li><a href="team.html#invitedspeaker">Invited speakers</a></li>
 												<li><a href="team.html#management">Organizing Committee</a></li>
 											</ul>

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
 										<li>
 											<span class="opener">Team</span>
 											<ul>
-												<li><a href="team.html#speaker">Speakers</a></li>
+												<li><a href="team.html#teacher">Teachers</a></li>
 												<li><a href="team.html#invitedspeaker">Invited speakers</a></li>
 												<li><a href="team.html#management">Organizing Committee</a></li>
 											</ul>

--- a/news.html
+++ b/news.html
@@ -42,8 +42,10 @@
                                     <p>Website template was downloaded from <a href='https://html5up.net/'>HTML5 UP</a>. Template name is <a href='https://html5up.net/editorial'>Editorial</a>.</p>
                                     <p>Icons were downloaded from <a href='https://fontawesome.com/'>Font Awesome</a></p>
                                     <p>Images were either downloaded from <a href='https://unsplash.com/'> Unsplash </a>, or private collections which were donated by our management team.</p>
-
-
+									<header class="major">
+										<h2>2021.03.16 Update team's information</h2>
+									</header>
+									<p>The organizing committee and teachers' information are updated</p>
 						</div>
 					</div>
 
@@ -70,7 +72,7 @@
 										<li>
 											<span class="opener">Team</span>
 											<ul>
-												<li><a href="team.html#speaker">Speakers</a></li>
+												<li><a href="team.html#teacher">Teachers</a></li>
 												<li><a href="team.html#invitedspeaker">Invited speakers</a></li>
 												<li><a href="team.html#management">Organizing Committee</a></li>
 											</ul>

--- a/schedule.html
+++ b/schedule.html
@@ -124,7 +124,7 @@
 										<li>
 											<span class="opener">Team</span>
 											<ul>
-												<li><a href="team.html#speaker">Speakers</a></li>
+												<li><a href="team.html#teacher">Teachers</a></li>
 												<li><a href="team.html#invitedspeaker">Invited speakers</a></li>
 												<li><a href="team.html#management">Organizing Committee</a></li>
 											</ul>

--- a/team.html
+++ b/team.html
@@ -35,9 +35,9 @@
 									</ul> -->
 								</header>
                                 
-                                <section id='speaker'>
+                                <section id='teacher'>
                                     <header class="major">
-										<h2>Speakers</h2>
+										<h2>Teachers</h2>
 									</header>
 									<div class="profile-grid">
 									<div class="profile-wrapper">
@@ -138,7 +138,7 @@
 										<li>
 											<span class="opener">Team</span>
 											<ul>
-												<li><a href="team.html#speaker">Speakers</a></li>
+												<li><a href="team.html#teacher">Teachers</a></li>
 												<li><a href="team.html#invitedspeaker">Invited speakers</a></li>
 												<li><a href="team.html#management">Organizing Committee</a></li>
 											</ul>


### PR DESCRIPTION
@MacyL Would you take a look at the changes that I made? I'd like to change the headline "Speakers" into "Teachers" so that is it is clearly separated from our "Invited speakers". Is it ok to also changed "#teacher" or should I leave it as is?